### PR TITLE
Fix invalid font extension (.tff -> .TTF) causing SetFont error

### DIFF
--- a/CharacterStatsTbcUI.lua
+++ b/CharacterStatsTbcUI.lua
@@ -415,7 +415,7 @@ function UIConfig:SetupConfigInterface()
     CSC_ConfigFrame.titleString = CSC_ConfigFrame.title:CreateFontString(nil, "OVERLAY", "GameFontNormal");
     CSC_ConfigFrame.titleString:SetPoint("TOPLEFT", CSC_ConfigFrame, "TOPLEFT", 10, -10);
     CSC_ConfigFrame.titleString:SetText('|cff00c0ffCharacterStatsTBC|r');
-    CSC_ConfigFrame.titleString:SetFont("Fonts\\FRIZQT__.tff", 20, "OUTLINE");
+	CSC_ConfigFrame.titleString:SetFont("Fonts\\FRIZQT__.TTF", 20, "OUTLINE");
 
     -- Checkboxes
     CSC_ConfigFrame.chkBtnUseBlizzardBlockValue = CreateFrame("CheckButton", "default", CSC_ConfigFrame, "UICheckButtonTemplate");


### PR DESCRIPTION
When using the addon on WoW TBC Anniversary, the Character Stats panel wasn't displaying any stats. BugSack caught the following error, which appears to be the root cause:
```
6x FontString:SetFont(): Invalid font asset (Fonts\FRIZQT__.tff): file not found
Lua Taint: CharacterStatsTBC
[CharacterStatsTBC/CharacterStatsTbcUI.lua]:418: in function 'SetupConfigInterface'
[CharacterStatsTBC/CharacterStatsTbcUI.lua]:323: in function 'CreateMenu'
[CharacterStatsTBC/CharacterStatsTbcUI.lua]:579: in function <...aceCharacterStatsTBC/CharacterStatsTbcUI.lua:575>
```
